### PR TITLE
Final 2017 m cv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ For the current best tau trigger scale factors for 2017 data and MC do:
 ```
 cd $CMSSW_BASE/src
 mkdir TauAnalysisTools
-cd TauAnalysisTools
-git clone -b final_2017_MCv2 git@github.com:truggles/TauTriggerSFs.git TauTriggerSFs
+pushd TauAnalysisTools
+git clone -b final_2017_MCv2 git@github.com:cms-tau-pog/TauTriggerSFs.git TauTriggerSFs
+popd
+scram b -j 8
 ```
 The c++ interface require you to scram b after checkout. If you do not place the code in the above hierarchy within CMSSW
 the python paths are not guaranteed to work.

--- a/python/getTauTriggerSFs.py
+++ b/python/getTauTriggerSFs.py
@@ -61,28 +61,34 @@ class getTauTriggerSFs :
         self.fitUncMCMap[ 10 ] = self.f.Get('%s_%s%s_dm10_MC_errorBand' % (self.trigger, self.tauWP, self.wpType ) )
         
 
+        # Because of low statistics in the problem region of the barrel, we apply the Eta-Phi corrections
+        # based on taus passing the vloose MVA WP. This provides the most statistically robust measurement
+        # for the correction. Considering the three Eta-Phi regions should not have significantly different
+        # SF adjustments for different MVA WPs, this should also be a safe choice.
+        etaPhiWP = 'vloose'
+
         # Load the TH2s containing the eta phi efficiency corrections
         # This is done per decay mode: 0, 1, 10.
         self.effEtaPhiDataMap = {}
         self.effEtaPhiMCMap = {}
-        self.effEtaPhiDataMap[ 0 ] = self.f.Get('%s_%s%s_dm0_DATA' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiDataMap[ 1 ] = self.f.Get('%s_%s%s_dm1_DATA' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiDataMap[ 10 ] = self.f.Get('%s_%s%s_dm10_DATA' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiMCMap[ 0 ] = self.f.Get('%s_%s%s_dm0_MC' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiMCMap[ 1 ] = self.f.Get('%s_%s%s_dm1_MC' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiMCMap[ 10 ] = self.f.Get('%s_%s%s_dm10_MC' % (self.trigger, self.tauWP, self.wpType) )
+        self.effEtaPhiDataMap[ 0 ] = self.f.Get('%s_%s%s_dm0_DATA' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiDataMap[ 1 ] = self.f.Get('%s_%s%s_dm1_DATA' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiDataMap[ 10 ] = self.f.Get('%s_%s%s_dm10_DATA' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiMCMap[ 0 ] = self.f.Get('%s_%s%s_dm0_MC' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiMCMap[ 1 ] = self.f.Get('%s_%s%s_dm1_MC' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiMCMap[ 10 ] = self.f.Get('%s_%s%s_dm10_MC' % (self.trigger, etaPhiWP, self.wpType) )
 
 
         # Eta Phi Averages
         # This is done per decay mode: 0, 1, 10.
         self.effEtaPhiAvgDataMap = {}
         self.effEtaPhiAvgMCMap = {}
-        self.effEtaPhiAvgDataMap[ 0 ] = self.f.Get('%s_%s%s_dm0_DATA_AVG' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiAvgDataMap[ 1 ] = self.f.Get('%s_%s%s_dm1_DATA_AVG' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiAvgDataMap[ 10 ] = self.f.Get('%s_%s%s_dm10_DATA_AVG' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiAvgMCMap[ 0 ] = self.f.Get('%s_%s%s_dm0_MC_AVG' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiAvgMCMap[ 1 ] = self.f.Get('%s_%s%s_dm1_MC_AVG' % (self.trigger, self.tauWP, self.wpType) )
-        self.effEtaPhiAvgMCMap[ 10 ] = self.f.Get('%s_%s%s_dm10_MC_AVG' % (self.trigger, self.tauWP, self.wpType) )
+        self.effEtaPhiAvgDataMap[ 0 ] = self.f.Get('%s_%s%s_dm0_DATA_AVG' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiAvgDataMap[ 1 ] = self.f.Get('%s_%s%s_dm1_DATA_AVG' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiAvgDataMap[ 10 ] = self.f.Get('%s_%s%s_dm10_DATA_AVG' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiAvgMCMap[ 0 ] = self.f.Get('%s_%s%s_dm0_MC_AVG' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiAvgMCMap[ 1 ] = self.f.Get('%s_%s%s_dm1_MC_AVG' % (self.trigger, etaPhiWP, self.wpType) )
+        self.effEtaPhiAvgMCMap[ 10 ] = self.f.Get('%s_%s%s_dm10_MC_AVG' % (self.trigger, etaPhiWP, self.wpType) )
 
 
     # Make sure we stay on our histograms

--- a/python/test_SFs.py
+++ b/python/test_SFs.py
@@ -96,7 +96,7 @@ def make_plots( tauSFs, target_type = 'ditau', dm=0 ) :
     leg.Draw('same')
     g.SetTitle( '%s, type: %s, WP: %s' % (name, wp, tauWP) )
     p.Update()
-    c.SaveAs('/afs/cern.ch/user/t/truggles/www/tauSFs/Feb19_new_SFs/'+name+'_'+wp+'_'+tauWP+'_DM'+str(dm)+'.png')
+    c.SaveAs('test_plots/'+name+'_'+wp+'_'+tauWP+'_DM'+str(dm)+'.png')
 
     del sfs, sfs2, sfs3, g, g2, g3, mg
 

--- a/src/TauTriggerSFs2017.cc
+++ b/src/TauTriggerSFs2017.cc
@@ -90,24 +90,31 @@ TauTriggerSFs2017::TauTriggerSFs2017(const std::string& inputFileName, const std
   fitUncMCMap_ [10] = loadTH1(inputFile_, Form("%s_%s%s_dm10_MC_errorBand", trigger_.data(), tauWP_.data(), wpType_.data()));
 
 
+
+  // Because of low statistics in the problem region of the barrel, we apply the Eta-Phi corrections
+  // based on taus passing the vloose MVA WP. This provides the most statistically robust measurement
+  // for the correction. Considering the three Eta-Phi regions should not have significantly different
+  // SF adjustments for different MVA WPs, this should also be a safe choice.
+  std::string etaPhiWP = "vloose";
+
   // Load the TH2s containing the eta phi efficiency corrections
   // This is done per decay mode: 0, 1, 10.
-  effEtaPhiDataMap_ [ 0] = loadTH2(inputFile_, Form("%s_%s%s_dm0_DATA", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiDataMap_ [ 1] = loadTH2(inputFile_, Form("%s_%s%s_dm1_DATA", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiDataMap_ [10] = loadTH2(inputFile_, Form("%s_%s%s_dm10_DATA", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiMCMap_ [ 0] = loadTH2(inputFile_, Form("%s_%s%s_dm0_MC", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiMCMap_ [ 1] = loadTH2(inputFile_, Form("%s_%s%s_dm1_MC", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiMCMap_ [10] = loadTH2(inputFile_, Form("%s_%s%s_dm10_MC", trigger_.data(), tauWP_.data(), wpType_.data()));
+  effEtaPhiDataMap_ [ 0] = loadTH2(inputFile_, Form("%s_%s%s_dm0_DATA", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiDataMap_ [ 1] = loadTH2(inputFile_, Form("%s_%s%s_dm1_DATA", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiDataMap_ [10] = loadTH2(inputFile_, Form("%s_%s%s_dm10_DATA", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiMCMap_ [ 0] = loadTH2(inputFile_, Form("%s_%s%s_dm0_MC", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiMCMap_ [ 1] = loadTH2(inputFile_, Form("%s_%s%s_dm1_MC", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiMCMap_ [10] = loadTH2(inputFile_, Form("%s_%s%s_dm10_MC", trigger_.data(), etaPhiWP.data(), wpType_.data()));
 
 
   // Eta Phi Averages
   // This is done per decay mode: 0, 1, 10.
-  effEtaPhiAvgDataMap_ [ 0] = loadTH2(inputFile_, Form("%s_%s%s_dm0_DATA_AVG", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiAvgDataMap_ [ 1] = loadTH2(inputFile_, Form("%s_%s%s_dm1_DATA_AVG", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiAvgDataMap_ [10] = loadTH2(inputFile_, Form("%s_%s%s_dm10_DATA_AVG", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiAvgMCMap_ [ 0] = loadTH2(inputFile_, Form("%s_%s%s_dm0_MC_AVG", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiAvgMCMap_ [ 1] = loadTH2(inputFile_, Form("%s_%s%s_dm1_MC_AVG", trigger_.data(), tauWP_.data(), wpType_.data()));
-  effEtaPhiAvgMCMap_ [10] = loadTH2(inputFile_, Form("%s_%s%s_dm10_MC_AVG", trigger_.data(), tauWP_.data(), wpType_.data()));
+  effEtaPhiAvgDataMap_ [ 0] = loadTH2(inputFile_, Form("%s_%s%s_dm0_DATA_AVG", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiAvgDataMap_ [ 1] = loadTH2(inputFile_, Form("%s_%s%s_dm1_DATA_AVG", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiAvgDataMap_ [10] = loadTH2(inputFile_, Form("%s_%s%s_dm10_DATA_AVG", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiAvgMCMap_ [ 0] = loadTH2(inputFile_, Form("%s_%s%s_dm0_MC_AVG", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiAvgMCMap_ [ 1] = loadTH2(inputFile_, Form("%s_%s%s_dm1_MC_AVG", trigger_.data(), etaPhiWP.data(), wpType_.data()));
+  effEtaPhiAvgMCMap_ [10] = loadTH2(inputFile_, Form("%s_%s%s_dm10_MC_AVG", trigger_.data(), etaPhiWP.data(), wpType_.data()));
 }
 
 


### PR DESCRIPTION
* Update checkout instructions in README for cms-tau-pog
* Change to use VLoose MVA WP for all eta-phi corrections

Because of low statistics in the problem region of the barrel, we apply the Eta-Phi corrections based on taus passing the vloose MVA WP. This provides the most statistically robust measurement for the correction. Considering the three Eta-Phi regions should not have significantly different SF adjustments for different MVA WPs, this should also be a safe choice.

@hsert can you take a look at these changes and merge when ready?